### PR TITLE
Implement round and vote logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# proyecto-impostor
+# Proyecto Impostor
+
+This repository contains a minimal implementation of the core logic for the
+**Impostor Futbolero** game. The important pieces are:
+
+- `src/gameLogic.js` – functions `tallyAndAdvance` and `continueToNextRound`.
+- `src/submitVote.js` – client side validation for voting.
+- `src/VoteBox.jsx` – React component that only lists alive players and honours
+  the optional `limitTo` list during a re-vote and hides the selector if the
+  user was expelled.
+- `src/RoomView.jsx` – simplified view showing the conditional rendering of the
+  re-vote card, the reveal screen and the host-only auto tally behaviour.
+
+## Manual test script
+
+Run the following script to simulate two rounds with four players. The first
+round expels an innocent, the second one expels another innocent which leads to
+parity (1 impostor vs 1 innocent) and therefore an impostor victory. A variant
+is included where the impostor is expelled in round 2.
+
+```bash
+node test/gameLogic.test.js
+```
+
+Expected output shows the room phase advancing to `reveal` after each round and
+finally to `end` with `winner: "impostor"`.
+
+## Manual test plan
+
+1. **Ronda 1 – expulsan inocente**
+   - Todos votan a un inocente.
+   - Se pasa a `phase="reveal"` mostrando que era inocente.
+   - Host presiona continuar y comienza la ronda 2.
+   - El expulsado ya no puede votar en rondas futuras.
+2. **Ronda 2 – expulsan inocente**
+   - De nuevo se expulsa un inocente.
+   - Quedan 1 impostor y 1 inocente → `phase="end"`, ganador impostor.
+3. **Variante**
+   - Si en la segunda ronda expulsan al impostor, `phase="end"` muestra
+     ganador inocentes.
+
+These cases are covered in the script above but can also be tested manually in a
+full application.
+

--- a/src/RoomView.jsx
+++ b/src/RoomView.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect } from 'react';
+import VoteBox from './VoteBox';
+
+/**
+ * Simplified room view showing how different phases render specific cards.
+ * It highlights two key conditions from the spec:
+ *  - The re-vote card only appears when `tieCandidates` has entries.
+ *  - After a successful vote the reveal card is always shown with a single
+ *    "Continuar" button for the host.
+ */
+export default function RoomView({ room, players, votes, meUid, hostUid, tallyAndAdvance }) {
+  const alivePlayers = players.filter(p => p.alive);
+  const isHost = meUid === hostUid;
+  const isRevote = room.phase === 'vote' && room.tieCandidates?.length;
+
+  // 3) Tally automático cuando todos los vivos ya votaron (solo host).
+  useEffect(() => {
+    const aliveCount = alivePlayers.length;
+    if (
+      isHost &&
+      (room.phase === 'clues' || room.phase === 'vote') &&
+      votes.length === aliveCount &&
+      aliveCount > 0
+    ) {
+      tallyAndAdvance && tallyAndAdvance();
+    }
+  }, [votes.length, players, room.phase, isHost, tallyAndAdvance, meUid]);
+
+  if (room.phase === 'vote') {
+    return (
+      <div>
+        <h2>Votación</h2>
+        {isRevote && <div className="revote">Re-voto por empate</div>}
+        <VoteBox
+          players={players}
+          meUid={meUid}
+          limitTo={room.tieCandidates}
+          value={''}
+          onChange={() => {}}
+          onSubmit={() => {}}
+        />
+        {isHost && isRevote && <button>Cerrar re-voto</button>}
+      </div>
+    );
+  }
+
+  if (room.phase === 'reveal') {
+    const expelled = players.find(p => p.uid === room.lastExpelled);
+    return (
+      <div className="reveal">
+        <p>
+          Expulsaron a <strong>{expelled ? expelled.name : 'alguien'}</strong> —{' '}
+          {room.lastExpelledWasImpostor ? 'ERA IMPOSTOR' : 'ERA INOCENTE'}
+        </p>
+        {isHost && <button>Continuar a Ronda {room.round + 1}</button>}
+      </div>
+    );
+  }
+
+  return <div>Fase: {room.phase}</div>;
+}
+

--- a/src/VoteBox.jsx
+++ b/src/VoteBox.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Dropdown + button to submit a vote. The list of options only includes
+ * players that are alive and, when `limitTo` is provided, is restricted to
+ * that subset (used during re-vote).
+ */
+export default function VoteBox({ players, meUid, limitTo, value, onChange, onSubmit }) {
+  const me = players.find(p => p.uid === meUid);
+  const options = players
+    .filter(p => p.alive)
+    .filter(p => !limitTo || limitTo.includes(p.uid));
+
+  // 2) Si el jugador fue expulsado, no debe ver el selector de voto.
+  if (!me?.alive) {
+    return <div className="vote-box">Estás expulsado, no podés votar</div>;
+  }
+
+  return (
+    <div className="vote-box">
+      <select value={value} onChange={e => onChange(e.target.value)}>
+        <option value="">Elegí jugador...</option>
+        {options.map(p => (
+          <option key={p.uid} value={p.uid} disabled={p.uid === meUid}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+      <button onClick={onSubmit} disabled={!value || value === meUid}>
+        Votar
+      </button>
+    </div>
+  );
+}
+

--- a/src/gameLogic.js
+++ b/src/gameLogic.js
@@ -1,0 +1,142 @@
+// Core game logic for Impostor Futbolero.
+// Implements tallying votes and advancing rounds exactly as per spec.
+
+// Utility shuffle function used when generating new turn order.
+function shuffle(arr) {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/**
+ * Tally votes for the current round and update the room accordingly.
+ *
+ * @param {Object} room          Current room document snapshot data.
+ * @param {Array<Object>} votes  Votes for the round [{voterUid, targetUid}].
+ * @param {Array<Object>} players List of players with `uid` and `alive`.
+ * @param {Object} deps          Dependency bag with Firestore helpers:
+ *   - updateRoom(partial)
+ *   - setPlayerAlive(uid, alive)
+ *   - deleteVotesRound(round)
+ *
+ * The function mirrors the pseudocode in the specification. If there is a
+ * clear winner, the player is marked as not alive and the remaining counts are
+ * evaluated: if the game ends it sets `phase="end"` with the proper winner,
+ * otherwise it fills `lastExpelled`/`lastExpelledWasImpostor` and moves to
+ * `phase="reveal"`. On tie, it goes back to `phase="vote"` with the
+ * `tieCandidates` filled after clearing the votes so a re-vote can happen.
+ */
+async function tallyAndAdvance(room, votes, players, deps) {
+  const counts = {};
+  for (const v of votes) {
+    // Ignore votes targeting dead players (should not happen, but defensive).
+    const targetAlive = players.find(p => p.uid === v.targetUid && p.alive);
+    if (!targetAlive) continue;
+    counts[v.targetUid] = (counts[v.targetUid] || 0) + 1;
+  }
+
+  const max = Math.max(...Object.values(counts), 0);
+  const top = Object.entries(counts)
+    .filter(([_, c]) => c === max)
+    .map(([uid]) => uid);
+
+  // Tie => start re-vote between top candidates and wipe previous votes.
+  if (top.length !== 1) {
+    await deps.deleteVotesRound(room.round);
+    await deps.updateRoom({ phase: 'vote', tieCandidates: top });
+    return { phase: 'vote', tieCandidates: top };
+  }
+
+  // Clear winner => expel and evaluate victory conditions.
+  const expelled = top[0];
+  await deps.setPlayerAlive(expelled, false); // a) mark expelled player
+
+  const expIsImp = room.impostorUids.includes(expelled);
+  const newImpostorUids = expIsImp
+    ? room.impostorUids.filter(u => u !== expelled)
+    : room.impostorUids;
+
+  const survivors = players.filter(p => p.uid !== expelled && p.alive);
+  const impsAfter = survivors.filter(p => newImpostorUids.includes(p.uid)).length;
+  const innocentsAfter = survivors.length - impsAfter;
+
+  if (impsAfter === 0) {
+    await deps.updateRoom({
+      phase: 'end',
+      winner: 'innocents',
+      lastExpelled: expelled,
+      lastExpelledWasImpostor: expIsImp,
+      impostorUids: newImpostorUids,
+      tieCandidates: null
+    });
+    await deps.deleteVotesRound(room.round);
+    return { phase: 'end', winner: 'innocents', expelled };
+  }
+
+  if (impsAfter >= innocentsAfter) {
+    await deps.updateRoom({
+      phase: 'end',
+      winner: 'impostor',
+      lastExpelled: expelled,
+      lastExpelledWasImpostor: expIsImp,
+      impostorUids: newImpostorUids,
+      tieCandidates: null
+    });
+    await deps.deleteVotesRound(room.round);
+    return { phase: 'end', winner: 'impostor', expelled };
+  }
+
+  await deps.updateRoom({
+    phase: 'reveal',
+    lastExpelled: expelled,
+    lastExpelledWasImpostor: expIsImp,
+    impostorUids: newImpostorUids,
+    tieCandidates: null // c) remove tie candidates so re-vote button disappears
+  });
+
+  await deps.deleteVotesRound(room.round); // d) clear votes of the round
+  return { phase: 'reveal', expelled };
+}
+
+/**
+ * Continue from the reveal screen to the next step depending on remaining
+ * players.
+ *
+ * @param {Object} room
+ * @param {Array<Object>} players
+ * @param {Object} deps Dependency bag:
+ *   - updateRoom(partial)
+ *   - clearVotesRound(round)
+ *
+ * Votes were cleared when tallying, but we clean again just in case and
+ * initialise state for the next round.
+ */
+async function continueToNextRound(room, players, deps) {
+  const alive = players.filter(p => p.alive);
+
+  // Clear votes of the previous round before changing state.
+  await deps.clearVotesRound(room.round);
+
+  // Next round with new turn order of alive players only.
+  const nextOrder = shuffle(alive.map(p => p.uid));
+  await deps.updateRoom({
+    phase: 'clues',
+    round: room.round + 1,
+    turnOrder: nextOrder,
+    turnIndex: 0,
+    tieCandidates: null,
+    lastExpelled: null,
+    lastExpelledWasImpostor: null
+  });
+  return 'next-round';
+}
+
+module.exports = {
+  tallyAndAdvance,
+  continueToNextRound,
+  shuffle
+};
+

--- a/src/submitVote.js
+++ b/src/submitVote.js
@@ -1,0 +1,40 @@
+// Handles client-side validation before writing a vote document.
+// Ensures that a player cannot vote themselves, only alive players can vote
+// and that candidates are restricted during a re-vote.
+
+/**
+ * @param {Object} room Room data including `round` and optional `tieCandidates`.
+ * @param {Array<Object>} players All players with uid & alive.
+ * @param {string} voterUid UID of the voter.
+ * @param {string} targetUid UID being voted.
+ * @param {Object} deps Dependency bag with Firestore helper `saveVote(data)`.
+ */
+async function submitVote(room, players, voterUid, targetUid, deps) {
+  const voter = players.find(p => p.uid === voterUid);
+  const target = players.find(p => p.uid === targetUid);
+
+  // 1) Un jugador expulsado no puede volver a votar.
+  if (!voter || !voter.alive) {
+    throw new Error('Estás expulsado, no podés votar');
+  }
+  if (voterUid === targetUid) {
+    throw new Error('No podés votarte');
+  }
+  if (!target || !target.alive) {
+    throw new Error('El jugador no está disponible para votar.');
+  }
+  if (room.tieCandidates && !room.tieCandidates.includes(targetUid)) {
+    throw new Error('Solo se puede votar entre los empatados.');
+  }
+
+  // All validations passed – persist vote.
+  await deps.saveVote({
+    round: room.round,
+    voterUid,
+    targetUid,
+    at: new Date().toISOString()
+  });
+}
+
+module.exports = submitVote;
+

--- a/test/gameLogic.test.js
+++ b/test/gameLogic.test.js
@@ -1,0 +1,116 @@
+const assert = require('assert');
+const { tallyAndAdvance, continueToNextRound } = require('../src/gameLogic');
+const submitVote = require('../src/submitVote');
+
+// Helper to create dependency bags that simply mutate local objects.
+function createDeps(room, players) {
+  return {
+    async updateRoom(partial) {
+      Object.assign(room, partial);
+    },
+    async setPlayerAlive(uid, alive) {
+      const p = players.find(pl => pl.uid === uid);
+      if (p) p.alive = alive;
+    },
+    async deleteVotesRound() {
+      // no-op for tests
+    },
+    async clearVotesRound() {
+      // no-op for tests
+    }
+  };
+}
+
+(async () => {
+  // --- Scenario 1: second round leads to impostor victory ---
+  const room = {
+    round: 1,
+    phase: 'vote',
+    impostorUids: ['d'],
+    tieCandidates: null,
+    lastExpelled: null,
+    lastExpelledWasImpostor: null
+  };
+  const players = [
+    { uid: 'a', name: 'A', alive: true },
+    { uid: 'b', name: 'B', alive: true },
+    { uid: 'c', name: 'C', alive: true },
+    { uid: 'd', name: 'D', alive: true } // impostor
+  ];
+  const deps = createDeps(room, players);
+
+  // Round 1: everyone votes C
+  let votes = [
+    { voterUid: 'a', targetUid: 'c' },
+    { voterUid: 'b', targetUid: 'c' },
+    { voterUid: 'c', targetUid: 'a' }, // irrelevant
+    { voterUid: 'd', targetUid: 'c' }
+  ];
+
+  await tallyAndAdvance(room, votes, players, deps);
+  assert.strictEqual(room.phase, 'reveal');
+  assert.strictEqual(room.lastExpelled, 'c');
+  assert.strictEqual(players.find(p => p.uid === 'c').alive, false);
+
+  await continueToNextRound(room, players, deps);
+  assert.strictEqual(room.phase, 'clues');
+  assert.strictEqual(room.round, 2);
+  assert.strictEqual(room.tieCandidates, null);
+
+  // Expelled player cannot vote in later rounds
+  try {
+    await submitVote(room, players, 'c', 'a', { saveVote: async () => {} });
+    assert.fail('Expelled player should not vote');
+  } catch (err) {
+    assert.ok(err.message.includes('Estás expulsado'));
+  }
+
+  // Round 2: A and D vote B -> B expelled leaving A vs D => impostor victory
+  votes = [
+    { voterUid: 'a', targetUid: 'b' },
+    { voterUid: 'b', targetUid: 'a' },
+    { voterUid: 'd', targetUid: 'b' }
+  ];
+
+  await tallyAndAdvance(room, votes, players, deps);
+  assert.strictEqual(room.phase, 'end');
+  assert.strictEqual(room.winner, 'impostor');
+  console.log('Scenario 1 winner:', room.winner);
+
+  // --- Scenario 2: second round expels impostor ---
+  const room2 = {
+    round: 1,
+    phase: 'vote',
+    impostorUids: ['d'],
+    tieCandidates: null,
+    lastExpelled: null,
+    lastExpelledWasImpostor: null
+  };
+  const players2 = [
+    { uid: 'a', name: 'A', alive: true },
+    { uid: 'b', name: 'B', alive: true },
+    { uid: 'c', name: 'C', alive: true },
+    { uid: 'd', name: 'D', alive: true } // impostor
+  ];
+  const deps2 = createDeps(room2, players2);
+
+  votes = [
+    { voterUid: 'a', targetUid: 'c' },
+    { voterUid: 'b', targetUid: 'c' },
+    { voterUid: 'c', targetUid: 'a' },
+    { voterUid: 'd', targetUid: 'c' }
+  ];
+  await tallyAndAdvance(room2, votes, players2, deps2);
+  await continueToNextRound(room2, players2, deps2);
+
+  // Round 2: everyone votes D (impostor)
+  votes = [
+    { voterUid: 'a', targetUid: 'd' },
+    { voterUid: 'b', targetUid: 'd' },
+    { voterUid: 'd', targetUid: 'a' }
+  ];
+  await tallyAndAdvance(room2, votes, players2, deps2);
+  assert.strictEqual(room2.phase, 'end');
+  assert.strictEqual(room2.winner, 'innocents');
+  console.log('Scenario 2 winner:', room2.winner);
+})();


### PR DESCRIPTION
## Summary
- Auto-tally votes once all alive players have voted and gate revote UI to real ties
- Forbid expelled players from voting or appearing in future options
- End game immediately when victory conditions are met, otherwise reveal and prep next round

## Testing
- `node test/gameLogic.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b62fda095c8329ad3c153cefc81de2